### PR TITLE
Improved pear dependency installation to use config file when present.

### DIFF
--- a/pear-install-deps
+++ b/pear-install-deps
@@ -33,19 +33,43 @@ if [ "$1" = '-h' ]; then
 	usage
 fi
 
+function get_channel_for_package() {
+	for ARG in "${ARGS[@]}"; do
+		ARG=${ARG/:$1}
+		if ! [[ $ARG =~ ':' ]]; then  # If we stripped a colon, we have a match.
+			CHANNEL=$ARG
+			return 0
+		fi
+	done
+	CHANNEL=''
+	return 1
+}
+
+DIR="$( cd -P "$( dirname "$0" )"/.. >/dev/null 2>&1 && pwd )"
+THIS_DIR="$( cd -P "$( dirname "$0" )"/. >/dev/null 2>&1 && pwd )"
 PEAR_OPTIONS="--alldeps"
 PEAR_PACKAGES_FILE="$DIR/Config/pear_packages.txt"
 
-# Bail out if PEAR isn't available to us, or no arguments were provided.
+# Bail out if PEAR isn't available to us.
 PEAR="$( which pear )"
 if [ $? -gt 0 ]; then
 	echo "!! The 'pear' command was not found on this system."
 	echo ""
 	exit 1
 fi
+
+# If no args provided, try reading the config file.
 if [ -z "$1" ]; then
-	usage
-	#@TODO: Check for $PEAR_PACKAGES_FILE. If present, populate $@ from it. Otherwise `exit 1`.
+	if [ -s "$PEAR_PACKAGES_FILE" ]; then
+		echo "## Loading channels/packages from '$PEAR_PACKAGES_FILE'."
+		mapfile -t ARGS < <( cat "$PEAR_PACKAGES_FILE" )
+	else
+		echo "!! No arguments provided, and no/empty config file at '$PEAR_PACKAGES_FILE'."
+		echo ""
+		exit 2
+	fi
+else
+	ARGS=$@
 fi
 
 ## Define accumulators for channel list and package list.
@@ -53,7 +77,7 @@ CHANNELS=()
 PACKAGES=()
 
 ## Compile channels and packages into their own lists.
-for ARG in "$@"; do
+for ARG in "${ARGS[@]}"; do
 	IFS=":" read -a PAIR <<< "$ARG"
 	if [ "${PAIR[1]+isset}" ]; then
 		CHANNELS+=(${PAIR[0]})
@@ -83,7 +107,8 @@ fi
 if [ "${#PACKAGES[@]}" -gt 0 ]; then
 	echo "## ${#PACKAGES[@]} packages to install: ${PACKAGES[@]}"
 	for PACKAGE in "${PACKAGES[@]}"; do
-		if ./pear-package-installed-dumb "$PACKAGE" "$CHANNEL"; then
+		get_channel_for_package $PACKAGE  # Sets $CHANNEL
+		if "$THIS_DIR/pear-package-installed-dumb" "$PACKAGE" "$CHANNEL"; then
 			echo "## Package '$PACKAGE' seems to already be installed. Skipping."
 			continue
 		else

--- a/pear-package-installed-dumb
+++ b/pear-package-installed-dumb
@@ -12,9 +12,9 @@ ${0##*/}
     is NOT installed. Will exit with 2 if the 'pear' executable
     is not available.
 
-	This is the ugly way to accomplish this, but the "right"
-	way in 'pear-installed-package' won't work because PEAR's
-	source code is super crusty.
+    This is the ugly way to accomplish this, but the "right"
+    way in 'pear-installed-package' won't work because PEAR's
+    source code is super crusty.
 
 Usage:
     bin/${0##*/} package [channel]
@@ -31,7 +31,7 @@ fi
 # Bail out if PEAR isn't available to us, or no arguments were provided.
 PEAR="$( which pear )"
 if [ $? -gt 0 ]; then
-	echo "!! The 'pear' commeand was not found on this system."
+	echo "!! The 'pear' command was not found on this system."
 	echo ""
 	exit 2
 fi


### PR DESCRIPTION
PEAR packages can now be managed using a config file, al-a composer,npm, etc.

Create a file at `Config/pear_packages.txt` with one `[channel:]package` pair per line, like so:

``` text
PHP_CodeSniffer
pear.cakephp.org:cakephp/CakePHP_CodeSniffer
pear.survivethedeepend.com:deepend/Mockery
hamcrest.googlecode.com/svn/pear:deepend/Mockery
```

The first line is an example of a package available from the default channel (pear.php.net). The last two lines indicate how to install additional channels that don't have a specific package related to them (supply a duplicate package name).

Use `pear-install-deps` without arguments to install/update channels and packages from the new config file. The script works around a huge number of janky problems surrounding PEAR and makes them somewhat automate-able.

It is included in the new `deps-install` (which in turn is now used in `update`), which detects the executables and associated config files for:
- PEAR
- composer
- npm

...and runs install commands for those that are present. _(Having a config present but the binary missing throws an error. If you aren't using one of these dep managers but have a config file in place: Either remove the config file or install the binary!)_
