### PR TITLE
B/misc fixes

### DIFF
--- a/db-backup
+++ b/db-backup
@@ -12,7 +12,9 @@ ${script}
     default database into a ZIP file located in a backups/ folder
     created in the project root (if necessary). Outputs the ZIP
     file's size as a crude verification step. Should be run from
-    the project root folder.
+    the project root folder. Will exit with an error code of 1 if
+    database credentials could not be obtained from the Cake app
+    via the `db-credentials` script.
 
 Usage:
     bin/${script}
@@ -30,15 +32,12 @@ if (isset($argv[1]) && $argv[1] == '-h') {
 // Set up variables.
 $dir = getcwd();
 $backupDir = $dir . '/backups';
-$configDir = $dir . '/Config';
-$dbConfigFile = $configDir . '/database.php';
 $date = date('Ymd-His');
-if (!is_readable($dbConfigFile)) {
-	echo "!! Failed to read database config file: '{$dbConfigFile}'" . PHP_EOL;
+try {
+	$db = new DbConfig();
+} catch (Exception $e) {
 	exit(1);
 }
-include $dbConfigFile;
-$db = new DATABASE_CONFIG();
 
 // Create an appropriate password clause for the command line.
 if (empty($db->default['password'])) {
@@ -70,4 +69,34 @@ function human_filesize($bytes, $decimals = 2) {
 	$sz = 'BKMGTP';
 	$factor = floor((strlen(intval($bytes)) - 1) / 3);
 	return (sprintf("%.{$decimals}f", intval($bytes) / pow(1024, $factor)) + 0) . @$sz[$factor];
+}
+
+//----------
+class DbConfig {
+	public $default = array();
+	public function __construct() {
+		$dir = getcwd();
+		$cmd = escapeshellcmd("{$dir}/bin/db-credentials");
+		$response = array();
+		$code = 0;
+		exec($cmd, $response, $code);
+
+		if (empty($response) || $code > 0) {
+			throw new RuntimeException('Unable to fetch Database config from db-credentials.');
+		}
+
+		foreach ($response as $line) {
+			if (!substr_count($line, '=')) {
+				continue;
+			}
+			list($key, $val) = explode('=', $line, 2);
+			$key = strtolower(str_replace('DB_', '', $key));
+			$val = substr($val, 1, -1);
+			$this->default[$key] = $val;
+		}
+
+		if (empty($this->default)) {
+			throw new RuntimeException('No Database config found.');
+		}
+	}
 }

--- a/db-credentials
+++ b/db-credentials
@@ -6,7 +6,10 @@
 // See db-login.sh for a usage pattern that preserves special char escaping for DB_PASS.
 //   Ref: http://stackoverflow.com/questions/16320858
 
-$dir = dirname(dirname(__FILE__));
+// DIR="$( cd -P "$( dirname "$0" )"/.. >/dev/null 2>&1 && pwd )"
+// BIN_DIR="$DIR/bin"
+
+$dir = dirname(dirname(__FILE__)); //@TODO: Needs to be relative, otherwise we get an attempt to load `project_root/Vendor/loadsys/Config/database.php` because this actual file is composer-installed and not actuall in `/bin`.
 $dbConfigFile = $dir . '/Config/database.php';
 include $dbConfigFile;
 $db = new DATABASE_CONFIG();

--- a/db-credentials
+++ b/db-credentials
@@ -2,21 +2,147 @@
 <?php
 // Usage: In another bash script, do this:
 //   eval $( bin/db-credentials.sh )
-// This will populate bash variables for DB_HOST, DB_NAME, DB_USER and DB_PASS.
-// See db-login.sh for a usage pattern that preserves special char escaping for DB_PASS.
+//
+// This will populate bash variables for DB_HOST, DB_DATABASE, DB_LOGIN
+// and DB_PASSWORD. See `db-login` for a usage pattern that preserves
+// special char escaping for DB_PASS.
+//
+// Attempts to obtain the current `::$default` database connection
+// settings from the Cake app's Config/database.php file. There are 3
+// cases to handle:
+//
+//   1. database.php is just a loader for `Configure::read('Database')`
+//      and the ConfigRead plugin is installed. We can obtain the values
+//      from a call to `bin/cake config_read.config_read -b Database.default`.
+//   2. database.php is just a loader, but ConfigRead is not available. We
+//      have to "fake" the `Configure` and `Cache` classes to be able to
+//      include `Config/core.php` directly.
+//   3. database.php uses the "stock" configuration, so we can include
+//      `Config/database.php` directly.
+//
 //   Ref: http://stackoverflow.com/questions/16320858
 
-// DIR="$( cd -P "$( dirname "$0" )"/.. >/dev/null 2>&1 && pwd )"
-// BIN_DIR="$DIR/bin"
 
-$dir = dirname(dirname(__FILE__)); //@TODO: Needs to be relative, otherwise we get an attempt to load `project_root/Vendor/loadsys/Config/database.php` because this actual file is composer-installed and not actuall in `/bin`.
-$dbConfigFile = $dir . '/Config/database.php';
-include $dbConfigFile;
-$db = new DATABASE_CONFIG();
+// Try using ConfigReadShell first, if it's available.
+try {
+	$db = new DbConfig();
+	printDbConfig($db);
+	exit(0);
+} catch (Exception $e) {}
 
-echo <<<EOD
+// Fallback (standard) approach.
+$dbConfigFile = getcwd() . '/Config/database.php';
+if ((include $dbConfigFile)) {
+	$db = new DATABASE_CONFIG();
+	printDbConfig($db);
+}
+
+// Outright failure case.
+else {
+	exit(2);
+}
+
+
+//----------
+function printDbConfig($db) {
+	echo <<<EOD
 DB_HOST="{$db->default['host']}"
-DB_NAME="{$db->default['database']}"
-DB_USER="{$db->default['login']}"
-DB_PASS="{$db->default['password']}"
+DB_DATABASE="{$db->default['database']}"
+DB_LOGIN="{$db->default['login']}"
+DB_PASSWORD="{$db->default['password']}"
 EOD;
+}
+
+//----------
+class DbConfig {
+	public $default = array();
+	public function __construct() {
+		$dir = getcwd();
+		$cmd = escapeshellcmd("{$dir}/bin/cake config_read.config_read -b Database.default");
+		$response = array();
+		$code = 0;
+		exec($cmd, $response, $code);
+
+		if (empty($response) || $code > 0) {
+			throw new RuntimeException('Unable to fetch Database config from ConfigReadShell.');
+		}
+
+		foreach ($response as $line) {
+			if (!substr_count($line, '=')) {
+				continue;
+			}
+			list($key, $val) = explode('=', $line, 2);
+			$key = strtolower(str_replace('DATABASE_DEFAULT_', '', $key));
+			$val = substr($val, 1, -1);
+			$this->default[$key] = $val;
+		}
+
+		if (empty($this->default)) {
+			throw new RuntimeException('No Database config found in Configure.');
+		}
+	}
+}
+
+//----------
+class Configure {
+	public static $storage = array();
+	public static function write($key, $value) {
+		$sub = array();
+		$ptr = &$sub;
+		foreach (explode('.', $key) as $part) {
+			$ptr[$part] = array();
+			$ptr = &$ptr[$part];
+		}
+		$ptr = $value;
+		self::$storage = self::merge(self::$storage, $sub);
+	}
+	public static function read($key) {
+		$sub = self::$storage;
+		if (substr_count($key, '.')) {
+			foreach (explode('.', $key) as $part) {
+				$sub = $sub[$part];
+			}
+		}
+		return $sub;
+	}
+	public static function load($file) {
+		if (!(include "Config/{$file}.php")) {
+			return false;
+		}
+		self::$storage = self::merge(self::$storage, $config);
+	}
+	//Ref: http://api.cakephp.org/2.5/source-class-Hash.html#661-700
+	public static function merge(array $data, $merge) {
+		$args = array_slice(func_get_args(), 1);
+		$return = $data;
+
+		foreach ($args as &$curArg) {
+			$stack[] = array((array)$curArg, &$return);
+		}
+		unset($curArg);
+
+		while (!empty($stack)) {
+			foreach ($stack as $curKey => &$curMerge) {
+				foreach ($curMerge[0] as $key => &$val) {
+					if (!empty($curMerge[1][$key]) && (array)$curMerge[1][$key] === $curMerge[1][$key] && (array)$val === $val) {
+						$stack[] = array(&$val, &$curMerge[1][$key]);
+					} elseif ((int)$key === $key && isset($curMerge[1][$key])) {
+						$curMerge[1][] = $val;
+					} else {
+						$curMerge[1][$key] = $val;
+					}
+				}
+				unset($stack[$curKey]);
+			}
+ 			unset($curMerge);
+		}
+		return $return;
+	}
+}
+
+//----------
+class Cache {
+	public static function config($key, $value) {
+		// Completely ignore this.
+	}
+}

--- a/db-login
+++ b/db-login
@@ -29,13 +29,13 @@ BIN_DIR="$DIR/bin"
 # Holy yuck, but nothing else works!
 eval $( ${BIN_DIR}/db-credentials )
 
-CMD="mysql --host=${DB_HOST} --database=${DB_NAME} --user=${DB_USER}"
+CMD="mysql --host=${DB_HOST} --database=${DB_DATABASE} --user=${DB_LOGIN}"
 PATTERN=" |'"
 
-if [[ ${DB_PASS} =~ ${PATTERN} ]]; then
-	${CMD} -p"${DB_PASS}"
-elif [ -n "${DB_PASS}" ]; then
-	${CMD} -p${DB_PASS}
+if [[ ${DB_PASSWORD} =~ ${PATTERN} ]]; then
+	${CMD} -p"${DB_PASSWORD}"
+elif [ -n "${DB_PASSWORD}" ]; then
+	${CMD} -p${DB_PASSWORD}
 else
 	${CMD}
 fi

--- a/docs-generate
+++ b/docs-generate
@@ -28,11 +28,8 @@ BIN_DIR="${DIR}/bin"
 CFG_FILE="$DIR/Config/phpdoc.xml"
 
 # Bail out if phpcs isn't available to us
-PHPDOC="$( which phpdoc )"
-if [ $? -gt 0 ]; then
-	PHPDOC="$BIN_DIR/phpdoc"
-	test -x $PHPDOC
-fi
+PHPDOC="./bin/phpdoc"
+test -x $PHPDOC
 if [ $? -gt 0 ]; then
 	echo "!! The 'phpdoc' command was not found on this system."
 	echo ""


### PR DESCRIPTION
Mostly overhauls the `db-*` scripts to make them compatible with database connection settings stored in `Configure` instead of directly in `DATABASE_CONFIG::$default` for example.