### PR TITLE
F/docs post

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following dependencies are assumed to be available on the target system and 
 
 * `bash`
 * `composer`
+* `curl`
 * `git`
 * `mail`
 * `mysql`

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "db-sample-data",
         "deploy",
         "docs-generate",
+        "docs-post",
         "email",
         "folder-delete-items-older-than-days",
         "git-currentbranch",

--- a/docs-post
+++ b/docs-post
@@ -10,13 +10,14 @@ DEST_URL=http://localhost/docs-manager.php
 #@TODO: Run the appropriate command to generate docs if output path is not already populated.
 
 SRC_DIR=tmp/coverage/html
-TMP_FILE=tmp/upload.zip
 PROJECT_NAME=${PROJECT_NAME}-coverage
 
-zip -rq9 "$TMP_FILE" "$SRC_DIR"
-curl \
- -FauthToken=$TOKEN \
- -FprojectName=$PROJECT_NAME \
- -Ffile=@"$TMP_FILE;type=application/zip" \
+# This ensures no intermediate directories are stored in the ZIP file.
+cd "$SRC_DIR"
+
+# Send the POST request, using ZIP data fed from stdin
+zip -rq8 - * | curl \
+ -F "authToken=$TOKEN" \
+ -F "projectName=$PROJECT_NAME" \
+ -F "file=@-;filename=upload.zip;type=application/zip" \
  $DEST_URL
-rm -f $TMP_FILE

--- a/docs-post
+++ b/docs-post
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# POST a zip of generated docs or coverage reports to loadsysdev.
+
+#@TODO: Enforce first and second args.
+PROJECT_NAME=${1:-eu-mk2}
+TOKEN=${2:-foobar}
+DEST_URL=http://localhost/docs-manager.php
+
+#@TODO: Add shortcut args for "docs" and "coverage" that set paths appropriately.
+#@TODO: Run the appropriate command to generate docs if output path is not already populated.
+
+SRC_DIR=tmp/coverage/html
+TMP_FILE=tmp/upload.zip
+PROJECT_NAME=${PROJECT_NAME}-coverage
+
+zip -rq9 "$TMP_FILE" "$SRC_DIR"
+curl \
+ -FauthToken=$TOKEN \
+ -FprojectName=$PROJECT_NAME \
+ -Ffile=@"$TMP_FILE;type=application/zip" \
+ $DEST_URL
+rm $TMP_FILE

--- a/docs-post
+++ b/docs-post
@@ -19,4 +19,4 @@ curl \
  -FprojectName=$PROJECT_NAME \
  -Ffile=@"$TMP_FILE;type=application/zip" \
  $DEST_URL
-rm $TMP_FILE
+rm -f $TMP_FILE

--- a/docs-post
+++ b/docs-post
@@ -4,7 +4,7 @@
 #@TODO: Enforce first and second args.
 PROJECT_NAME=${1:-eu-mk2}
 TOKEN=${2:-foobar}
-DEST_URL=http://localhost/docs-manager.php
+DEST_URL=http://docs.loadsysdev.com/docs-manager.php
 
 #@TODO: Add shortcut args for "docs" and "coverage" that set paths appropriately.
 #@TODO: Run the appropriate command to generate docs if output path is not already populated.
@@ -13,7 +13,7 @@ SRC_DIR=tmp/coverage/html
 PROJECT_NAME=${PROJECT_NAME}-coverage
 
 # This ensures no intermediate directories are stored in the ZIP file.
-cd "$SRC_DIR"
+cd "$SRC_DIR" >/dev/null 2>&1
 
 # Send the POST request, using ZIP data fed from stdin
 zip -rq8 - * | curl \
@@ -21,3 +21,6 @@ zip -rq8 - * | curl \
  -F "projectName=$PROJECT_NAME" \
  -F "file=@-;filename=upload.zip;type=application/zip" \
  $DEST_URL
+
+# Clean up json output from curl with an extra newline.
+echo ''


### PR DESCRIPTION
Adds a script intended to work with [beporter/docs-manager](https://github.com/beporter/docs-manager). Allows you to automate the process of uploading something like a code coverage report or generated html documentation from a test server (such as Travis) to a more permanent web server.

Should be about feature complete, but needs serious testing.

Could also use some logic to handle the json payload response from the server (right now it just spits it out on the command line.)