### PR TITLE
Clean up cache-clear's output.

### DIFF
--- a/cache-clear
+++ b/cache-clear
@@ -28,14 +28,11 @@ fi
 
 echo "## Clearing cache folders.";
 
-cat <<-'EOPHP' | bin/cake console
-	use Cake\Cache\Cache;
-	foreach (Cache::configured() as $key) {
-		Cache::clear(false, $key);
-		echo "Cleared: $key\n";
+cat <<-'EOPHP' | bin/cake console -q | head -n -1
+	foreach (\Cake\Cache\Cache::configured() as $key) {
+		\Cake\Cache\Cache::clear(false, $key);
+		echo "  - Cleared: $key\n";
 	}
-	return "Done";
+	exit;
 
 EOPHP
-
-


### PR DESCRIPTION
Completely removes the extraneous output, which helps when the script is embedded in others, like `deploy`.