### PR TITLE
Use single quotes when printing db-credentials for shell consumption

### DIFF
--- a/db-credentials
+++ b/db-credentials
@@ -46,10 +46,10 @@ else {
 //----------
 function printDbConfig($db) {
 	echo <<<EOD
-DB_HOST="{$db->default['host']}"
-DB_DATABASE="{$db->default['database']}"
-DB_LOGIN="{$db->default['login']}"
-DB_PASSWORD="{$db->default['password']}"
+DB_HOST='{$db->default['host']}'
+DB_DATABASE='{$db->default['database']}'
+DB_LOGIN='{$db->default['login']}'
+DB_PASSWORD='{$db->default['password']}'
 EOD;
 }
 


### PR DESCRIPTION
This prevents shell special characters from being interpreted inside the
variable values.