### PR TITLE
Adds Composer Requirement For PHP Parser Version 0.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "phpunit/phpunit": "~4.1",
         "phpdocumentor/phpdocumentor": "~2.0",
         "psy/psysh": "@stable",
-        "loadsys/loadsys_codesniffer": "~3.0"
+        "loadsys/loadsys_codesniffer": "~3.0",
+        "nikic/php-parser": "~0.9"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
Fixes bug with PHP Documentor with newer versions of PHP Parser, per bug reports https://github.com/phpDocumentor/phpDocumentor2/issues/1743 and https://github.com/yiisoft/yii2-apidoc/issues/20