### PR TITLE
Remove the Psysh Dependency

### DIFF
--- a/cache-clear
+++ b/cache-clear
@@ -28,11 +28,4 @@ fi
 
 echo "## Clearing cache folders.";
 
-cat <<-'EOPHP' | bin/cake console -q | head -n -1
-	foreach (\Cake\Cache\Cache::configured() as $key) {
-		\Cake\Cache\Cache::clear(false, $key);
-		echo "  - Cleared: $key\n";
-	}
-	exit;
-
-EOPHP
+bin/cake cache clear_all

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         }
     ],
     "require": {
+        "cakephp/cakephp": "~3.3",
         "phpunit/phpunit": "~4.1",
         "phpdocumentor/phpdocumentor": "~2.0",
-        "psy/psysh": "@stable",
         "loadsys/loadsys_codesniffer": "~3.0",
         "nikic/php-parser": "~0.9",
         "phpmetrics/phpmetrics": "^1.10"


### PR DESCRIPTION
Dumps psysh due to composer requirements for this failing against newer dependencies for CakePHP/Migrations and various inter-dependency requirements.

Adds requirement for this to work with CakePHP 3.3 due to the rewrite for the cache clearing script and to be honest you use this with Cake.
