### PR TITLE
F/2.x remove requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following dependencies are assumed to be available on the target system and 
 * `readlink`
 * `zip`
 
-Additionally, some scripts expect additional tools that should be automatically installed as composer dependencies to _this_ package:
+Additionally, some scripts expect additional tools that should be installed as composer dependencies in **your project:**
 
 * `bin/phpcs`
 * `bin/phpunit`
@@ -35,6 +35,8 @@ Additionally, some scripts expect additional tools that should be automatically 
 * `bin/cake` (composer-installed **by target project**)
 
 If these items are not available, some scripts may not function as expected.
+
+**IMPORTANT NOTE:** Previous versions of _this_ package automatically installed `PHP_CodeSniffer`, `PHPUnit`, and `phpDocumentor` via composer. These tools should now be added to your project's `composer.json` as specified below.
 
 
 ## Installation ##
@@ -48,7 +50,11 @@ Your project's own `composer.json` file should look something like this:
 ```json
 {
     "require": {
-		"loadsys/cakephp-shell-scripts": "2.0.*"
+		"loadsys/cakephp-shell-scripts": "2.0.*",
+		"phpunit/phpunit": "3.7.*",
+		"phpdocumentor/phpdocumentor": "2.*",
+		"squizlabs/php_codesniffer": "1.*",
+		"loadsys/loadsys_codesniffer": "~1.0"
     },
     "config": {
 		"bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,6 @@
             "email": "beporter@users.sourceforge.net"
         }
     ],
-    "require": {
-        "phpunit/phpunit": "3.7.*",
-        "phpdocumentor/phpdocumentor": "2.*",
-        "squizlabs/php_codesniffer": "1.*",
-        "loadsys/loadsys_codesniffer": "~1.0"
-    },
     "config": {
         "bin-dir": "bin"
     },


### PR DESCRIPTION
Setting composer required tool versions in this project is getting in the way of managing project tool updates. For example, in a CakePHP 2.10.x project using PHPUnit v5.x is possible, but blocked by the v3.7.* constraint here.